### PR TITLE
Fix configuration and package reference inconsistencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -277,7 +276,7 @@ omit = [
     "*/tests/*",
     "*/__pycache__/*",
     "*/site-packages/*",
-    "src/csv_editor/__main__.py",
+    "src/databeak/__main__.py",
 ]
 
 [tool.coverage.report]

--- a/src/databeak/_version.py
+++ b/src/databeak/_version.py
@@ -1,11 +1,11 @@
-"""Version information for CSV Editor."""
+"""Version information for DataBeak."""
 
 from __future__ import annotations
 
 import importlib.metadata
 
 try:
-    __version__ = importlib.metadata.version("csv-editor")
+    __version__ = importlib.metadata.version("databeak")
 except importlib.metadata.PackageNotFoundError:
     # Fallback for development mode
     __version__ = "1.0.2-dev"


### PR DESCRIPTION
Fix _version.py package loading, remove Python 3.9 classifier, and update coverage configuration. Closes #4, Closes #6, Closes #7