### PR TITLE
chore: add .pre-commit-cache/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,9 @@ uv.lock
 # Ruff
 .ruff_cache/
 
+# Pre-commit
+.pre-commit-cache/
+
 # CSV MCP Server specific
 *.csv
 *.tsv


### PR DESCRIPTION
Add pre-commit cache directory to gitignore to prevent accidentally committing temporary pre-commit hook files. Addresses code review recommendation from PR #14.