### PR TITLE
docs: fix arrogant tone and incorrect directory references

### DIFF
--- a/.claude/agents/test-coverage-analyzer.md
+++ b/.claude/agents/test-coverage-analyzer.md
@@ -33,16 +33,19 @@ DataBeak follows a structured testing approach:
 tests/
 ├── unit/                    # Fast, isolated module tests
 │   ├── models/             # Data models and session management
+│   ├── prompts/            # Prompt management
+│   ├── resources/          # Resource handling
 │   ├── servers/            # MCP server modules
-│   ├── servers/            # MCP server modules
-│   ├── utils/              # Utility functions
-│   └── resources/          # Resource handling
-├── integration/            # Component interaction tests
+│   ├── services/           # Service layer components
+│   └── utils/              # Utility functions
+├── security/               # Security test utilities
+├── utils/                  # Test utility functions
+├── integration/            # Component interaction tests (planned)
 │   ├── test_ai_accessibility.py
 │   ├── test_analytics_coverage.py
 │   ├── test_mcp_*.py
 │   └── test_session_coverage.py
-└── e2e/                    # End-to-end workflow tests
+└── e2e/                    # End-to-end workflow tests (planned)
     └── test_io_server_comprehensive_coverage.py
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,15 +33,13 @@ repository management guidance.
 
 ### Code Quality Standards
 
-DataBeak maintains exceptional code quality standards:
+DataBeak maintains strict code quality standards:
 
-- **Zero ruff violations** - Perfect linting compliance across all categories
-- **100% mypy compliance** - Complete type safety with no Any usage where
-  avoidable
-- **Comprehensive test coverage** - 1100+ unit tests with high coverage targets
-- **API design excellence** - No boolean traps, keyword-only parameters for
-  clarity
-- **Security best practices** - No silent exception handling, proper validation
+- **Zero ruff violations** - Clean linting compliance across all categories
+- **100% mypy compliance** - Strong type safety with minimal Any usage
+- **High test coverage** - 1100+ unit tests with good coverage targets
+- **Clear API design** - No boolean traps, keyword-only parameters for clarity
+- **Defensive practices** - No silent exception handling, proper validation
 
 **Use the `quality-gate-runner` agent** for comprehensive quality pipeline
 execution including linting, formatting, type checking, testing, and coverage
@@ -173,7 +171,51 @@ uv run mkdocs serve       # Serve docs locally
 - Pydantic models for data validation
 - Pandas for data operations
 - Session management with configurable timeouts
-- Comprehensive error handling and logging
+- Error handling and logging
+
+## Documentation Tone Standards
+
+DataBeak documentation maintains professional, factual tone:
+
+### Avoid Self-Aggrandizing Language
+
+**Prohibited terms**:
+
+- "exceptional", "perfect", "amazing", "outstanding", "superior"
+- "revolutionary", "cutting-edge", "world-class", "best-in-class"
+- "unparalleled", "state-of-the-art", "industry-leading", "premium", "elite"
+- "ultimate", "maximum", "optimal", "flawless"
+
+**Use factual alternatives**:
+
+- "exceptional standards" → "strict standards"
+- "perfect compliance" → "clean compliance"
+- "comprehensive coverage" → "high coverage"
+- "API design excellence" → "clear API design"
+- "security best practices" → "defensive practices"
+
+### Measurable Claims Only
+
+**Acceptable** (measurable):
+
+- "Zero ruff violations" (verifiable metric)
+- "100% mypy compliance" (measurable result)
+- "1100+ unit tests" (concrete count)
+
+**Prohibited** (subjective claims):
+
+- "production quality" (marketing speak)
+- "advanced analytics" (vague superlative)
+- "sophisticated architecture" (self-congratulatory)
+
+### Professional Descriptors
+
+Use measured, technical language:
+
+- "provides" not "delivers amazing"
+- "supports" not "offers comprehensive"
+- "implements" not "features advanced"
+- "handles" not "excels at"
 
 ## Additional Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,7 +259,7 @@ src/databeak/
 │   ├── __init__.py
 │   ├── csv_session.py   # Session management
 │   └── data_models.py   # Pydantic models
-├── tools/               # MCP tool implementations
+├── servers/             # MCP server implementations
 │   ├── __init__.py
 │   ├── io_operations.py
 │   ├── transformations.py

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Model Context Protocol (MCP).
   undo/redo
 - ⚡ **High Performance** - Handles large datasets with streaming and chunking
 - 🔒 **Session Management** - Multi-user support with isolated sessions
-- 🌟 **Production Quality** - Zero ruff violations, 100% mypy compliance,
-  comprehensive test coverage
+- 🌟 **Code Quality** - Zero ruff violations, 100% mypy compliance, high test
+  coverage
 
 ## Getting Started
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,14 +78,14 @@ src/databeak/
 
 ### Code Quality & Architecture
 
-- **Zero static analysis violations** - Perfect ruff compliance across all
+- **Zero static analysis violations** - Clean ruff compliance across all
   categories
-- **Complete type safety** - 100% mypy compliance with minimal Any usage
-- **Comprehensive test coverage** - 1100+ unit tests with high coverage targets
+- **Strong type safety** - 100% mypy compliance with minimal Any usage
+- **High test coverage** - 1100+ unit tests with good coverage targets
 - **Server composition pattern** - Modular FastMCP servers for different domains
 - **Context-based logging** - MCP-integrated logging for better traceability
-- **API design excellence** - Keyword-only boolean parameters, no boolean traps
-- **Security best practices** - Proper exception handling, input validation
+- **Clear API design** - Keyword-only boolean parameters, no boolean traps
+- **Defensive practices** - Proper exception handling, input validation
 
 ## Environment Variables
 

--- a/docs/testing-updates-summary.md
+++ b/docs/testing-updates-summary.md
@@ -103,10 +103,11 @@ uv run -m pytest tests/e2e/           # End-to-end tests
 tests/
 ├── unit/           # Fast, isolated module tests
 │   ├── models/     # Data models and session management
+│   ├── prompts/    # Prompt management
+│   ├── resources/  # Resource handling
 │   ├── servers/    # MCP server modules
-│   ├── tools/      # Individual tool operations
-│   ├── utils/      # Utility functions
-│   └── resources/  # Resource handling
+│   ├── services/   # Service layer components
+│   └── utils/      # Utility functions
 ├── integration/    # Component interaction tests
 │   ├── test_ai_accessibility.py
 │   ├── test_analytics_coverage.py

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -58,8 +58,10 @@ integration and E2E testing:
 tests/
 ├── unit/              # Mirrors src/ structure
 │   ├── models/
+│   ├── prompts/
+│   ├── resources/
 │   ├── servers/
-│   ├── tools/
+│   ├── services/
 │   └── utils/
 ├── integration/       # Cross-component tests
 └── e2e/              # Full workflow tests


### PR DESCRIPTION
## Summary

This PR addresses the concerns raised in PR #95 review comments and fixes documentation tone issues:

- ✅ **Fixed duplicate directory entry** in test-coverage-analyzer.md
- ✅ **Updated directory structure** to match actual codebase
- ✅ **Replaced incorrect references** from `tools/` to `servers/`
- ✅ **Removed self-aggrandizing language** throughout documentation
- ✅ **Added tone standards** to CLAUDE.md to prevent future issues

## Changes Made

### PR Review Fixes
- **Duplicate entry**: Removed duplicate `servers/` line in test-coverage-analyzer.md:37
- **Directory structure**: Updated to include `prompts/`, `services/`, `resources/` directories
- **Non-existent references**: Fixed `tools/` → `servers/` directory references

### Tone Improvements
- **"exceptional standards"** → **"strict standards"**
- **"perfect compliance"** → **"clean compliance"**
- **"comprehensive coverage"** → **"high coverage"**
- **"API design excellence"** → **"clear API design"**
- **"security best practices"** → **"defensive practices"**
- **"Production Quality"** → **"Code Quality"**

### Documentation Standards
Added comprehensive tone guidelines to CLAUDE.md:
- Prohibited self-aggrandizing terms list
- Factual alternatives for marketing speak
- Measurable vs subjective claims distinction
- Professional descriptor patterns

## Test Plan

- [x] All file references verified to exist
- [x] Directory structure matches actual codebase
- [x] Documentation links tested and working
- [x] Pre-commit hooks pass (mdformat applied)
- [x] No broken internal or external links found

🤖 Generated with [Claude Code](https://claude.ai/code)