### PR TITLE
feat: add readthedocs.io configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,10 +9,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  jobs:
-    pre_create_environment:
-      # Install uv
-      - pip install uv
 
 # Build documentation in the docs/ directory with MkDocs
 mkdocs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,27 @@
+---
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    pre_create_environment:
+      # Install uv
+      - pip install uv
+
+# Build documentation in the docs/ directory with MkDocs
+mkdocs:
+  configuration: mkdocs.yml
+
+# Python configuration
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
## Summary

- Add `.readthedocs.yaml` configuration file to enable readthedocs.io integration
- Configure Ubuntu 22.04 build environment with Python 3.11
- Install uv package manager during pre-build phase
- Use existing MkDocs configuration and docs dependencies from pyproject.toml

## Test plan

- [ ] Verify readthedocs.io can successfully build documentation
- [ ] Confirm all MkDocs plugins and dependencies are available during build
- [ ] Test that generated documentation matches local MkDocs build

🤖 Generated with [Claude Code](https://claude.ai/code)