### PR TITLE
Remove dynamic version control from build process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.26.0", "uv-dynamic-versioning"]
+requires = ["hatchling>=1.26.0"]
 build-backend = "hatchling.build"
 
 [project]
@@ -115,12 +115,6 @@ exclude = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/databeak"]
-
-[tool.hatch.version]
-source = "uv-dynamic-versioning"
-
-[tool.uv-dynamic-versioning]
-fallback-version = "0.0.0"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## Summary

- Removes `uv-dynamic-versioning` dependency from build requirements
- Eliminates `[tool.hatch.version]` and `[tool.uv-dynamic-versioning]` configuration sections
- Returns to explicit version management in `pyproject.toml`

This simplifies the build process and addresses concerns about dynamic version control complexity. Version is now managed directly in the project configuration rather than being computed at build time.

## Test plan

- [ ] Verify build completes successfully with `uv build`
- [ ] Confirm version reporting works correctly in server info endpoints
- [ ] Run full test suite with `uv run pytest -n auto tests/unit/`
- [ ] Validate package installation and import

🤖 Generated with [Claude Code](https://claude.com/claude-code)